### PR TITLE
[CBP-45084] Migrate kaniko build to cb-internal-shared-actions/build@v8

### DIFF
--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -23,31 +23,18 @@ jobs:
         run: |
           make verify
 
-      - name: Login to AWS
-        uses: https://github.com/cloudbees-io/configure-aws-credentials@v1
+      - id: build-image
+        name: Build, scan and push to ECR
+        uses: calculi-corp/cb-internal-shared-actions/build@v8
         with:
-          aws-region: us-east-1
-          role-to-assume: ${{ vars.oidc_staging_iam_role }}
-          role-duration-seconds: "3600"
-
-      - name: Configure container registry for Staging ECR
-        uses: https://github.com/cloudbees-io/configure-ecr-credentials@v1
-
-      - name: Build image
-        id: build-image
-        uses: https://github.com/cloudbees-io/kaniko@v1
-        with:
-          destination: 020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-git-global-credentials:${{ cloudbees.scm.sha }}${{ cloudbees.scm.branch == 'main' && ',020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-git-global-credentials:latest' || ''}}
-          labels: maintainer=sdp-pod-3,email=engineering@cloudbees.io
-
-      - id: slsa-attestation
-        name: Generate SLSA attestation
-        uses: calculi-corp/slsa-attestation@v1
-        with:
-          image-digest: 020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/configure-git-global-credentials@${{ steps.build-image.outputs.digest }}
-          aws-role-to-assume: ${{ vars.oidc_staging_iam_role }}
-          aws-region: us-east-1
-          aws-kms-alias: cbp-dev-kms-key-cosign
+          go-binary-build: "true"
+          go-binary-name: configure-git-global-credentials
+          kaniko-build: "true"
+          run-unit-test: "false"
+          registry-url: 020229604682.dkr.ecr.us-east-1.amazonaws.com
+          registry-image-name: actions/configure-git-global-credentials
+          registry-type: ECR
+          oidc-iam-role: ${{ vars.oidc_staging_iam_role }}
 
   test-ssh-key:
     if: cloudbees.api.url == 'https://api.saas-preprod.beescloud.com'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,37 +2,11 @@ FROM alpine:3.23 AS certs
 
 RUN apk add -U --no-cache ca-certificates
 
-FROM golang:1.26.0-alpine3.23 AS build
-
-WORKDIR /work
-
-COPY go.mod* go.sum* ./
-
-RUN go mod download
-
-COPY . .
-
-RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /build-out/ .
-
-## Add a secondary target that allows testing locally under similar conditions without modifying your local gitconfig
-
-FROM golang:1.26.0 AS testing
-
-COPY --from=build /build-out/* /usr/local/bin/
-
-RUN mkdir -p /cloudbees/home
-
-WORKDIR /cloudbees/workspace
-
-ENV HOME=/cloudbees/home
-
-ENTRYPOINT ["bash"]
-
 FROM scratch
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-COPY --from=build /build-out/* /usr/bin/
+COPY configure-git-global-credentials /usr/bin/
 
 WORKDIR /cloudbees/home
 
@@ -40,4 +14,3 @@ ENV HOME=/cloudbees/home
 ENV PATH=/usr/bin
 
 ENTRYPOINT ["configure-git-global-credentials"]
-


### PR DESCRIPTION
Replace the `kaniko@v1` + AWS/ECR login + `slsa-attestation` pipeline with a single `calculi-corp/cb-internal-shared-actions/build@v8` (services variant) call. Move go build into the workflow via `go-binary-build: true`. Dockerfile slimmed to runtime-only.

Generated by `/upgrade-shared-actions`.

Tracking: CBP-45084 (Upgrade Kaniko and V.x < V8 to shared actions V8: compliance, io).
